### PR TITLE
fix(docs): move mkdocs config out of docs directory

### DIFF
--- a/{{cookiecutter.project_distribution_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_distribution_name}}/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
     -   id: check-toml
     -   id: check-yaml
-        exclude: ^docs/mkdocs\.yml$
+        exclude: ^mkdocs\.yml$
     -   id: check-json
     -   id: end-of-file-fixer
     -   id: trailing-whitespace

--- a/{{cookiecutter.project_distribution_name}}/.readthedocs.yaml
+++ b/{{cookiecutter.project_distribution_name}}/.readthedocs.yaml
@@ -16,4 +16,4 @@ build:
 
 # Build documentation with MkDocs
 mkdocs:
-  configuration: docs/mkdocs.yml
+  configuration: mkdocs.yml

--- a/{{cookiecutter.project_distribution_name}}/docs/reference.md
+++ b/{{cookiecutter.project_distribution_name}}/docs/reference.md
@@ -48,7 +48,7 @@
     - [`pyproject.toml`][pyproject_toml]
     - [`.pre-commit-config.yaml`][_pre-commit-config_yaml]
     - [`.editorconfig`][_editorconfig]
-    - [`docs/mkdocs.yml`][docs_mkdocs_yml]
+    - [`mkdocs.yml`][docs_mkdocs_yml]
     - [`docs/wordlist.txt`][docs_wordlist_txt]
     - [`noxfile.py`][noxfile_py]
 - Standards
@@ -76,7 +76,7 @@
 [_pre-commit-config_yaml]: ../.pre-commit-config.yaml
 [pyproject_toml]: ../pyproject.toml
 [_editorconfig]: ../.editorconfig
-[docs_mkdocs_yml]: ./mkdocs.yml
+[docs_mkdocs_yml]: ../mkdocs.yml
 [docs_wordlist_txt]: ./wordlist.txt
 [noxfile_py]: ../noxfile.py
 

--- a/{{cookiecutter.project_distribution_name}}/mkdocs.yml
+++ b/{{cookiecutter.project_distribution_name}}/mkdocs.yml
@@ -6,9 +6,9 @@ repo_name: "{{ cookiecutter.__github_path }}"
 copyright: "Copyright &copy; {{ cookiecutter.year }}, {{ cookiecutter.full_name }}"
 
 # Documentation source directory (relative to this config file)
-docs_dir: "."
+docs_dir: "docs"
 # Build output directory (outside docs dir to avoid conflicts)
-site_dir: "../site"
+site_dir: "site"
 
 theme:
   name: material

--- a/{{cookiecutter.project_distribution_name}}/noxfile.py
+++ b/{{cookiecutter.project_distribution_name}}/noxfile.py
@@ -94,11 +94,11 @@ def test_code(session: nox.Session) -> None:
 def docs(session: nox.Session) -> None:
     """Build documentation with MkDocs."""
     install(session, groups=["docs"], root=True)
-    session.run("mkdocs", "build", "-f", "docs/mkdocs.yml")
+    session.run("mkdocs", "build", "-f", "mkdocs.yml")
 
 
 @nox.session(python=python_version, default=False)
 def docs_serve(session: nox.Session) -> None:
     """Serve documentation locally with live reload."""
     install(session, groups=["docs"], root=True)
-    session.run("mkdocs", "serve", "-f", "docs/mkdocs.yml")
+    session.run("mkdocs", "serve", "-f", "mkdocs.yml")


### PR DESCRIPTION
## Summary
- move `mkdocs.yml` from `docs/` to the project root in the generated template
- update docs tooling paths to use root config (`nox`, Read the Docs, and docs references)
- keep docs sources in `docs/` via `docs_dir: docs`

## Why
Issue #197 reports watcher/reload instability when the docs config lives under `docs/`.

## Validation
- rendered the template with `cruft` into `/tmp/crustypy-render2/python-project`
- ran `uv sync --group docs`
- ran `uv run nox -s docs` successfully
- started `uv run mkdocs serve -f mkdocs.yml` and confirmed it serves and watches `docs` + `mkdocs.yml`

Closes #197
